### PR TITLE
Optimize pipeline

### DIFF
--- a/1_inventory/log/summary_wqp_inventory.csv
+++ b/1_inventory/log/summary_wqp_inventory.csv
@@ -1,9 +1,9 @@
 CharacteristicName,n_sites,n_records
 "Alkalinity, total",99727,1754625
-Calcium,165524,2376725
-Chloride,183371,3089557
+Calcium,165524,2376760
+Chloride,183374,3089597
 Conductance,15,181
 Conductivity,38125,2624661
-Specific conductance,298461,11521500
+Specific conductance,298461,11521507
 "Specific Conductance, Calculated/Measured Ratio",1134,34503
 Specific conductivity***retired***use Specific conductance,85,1875

--- a/2_download/log/summary_wqp_data.csv
+++ b/2_download/log/summary_wqp_data.csv
@@ -1,9 +1,9 @@
 CharacteristicName,n_sites,n_records
 "Alkalinity, total",99727,1754625
-Calcium,165524,2376725
-Chloride,183371,3089557
+Calcium,165524,2376760
+Chloride,183374,3089597
 Conductance,15,181
 Conductivity,38125,2624661
-Specific conductance,298461,11521500
+Specific conductance,298278,11496355
 "Specific Conductance, Calculated/Measured Ratio",1134,34503
 Specific conductivity***retired***use Specific conductance,85,1875

--- a/README.md
+++ b/README.md
@@ -1,14 +1,24 @@
-# ds-pipelines-targets-example-wqp
-An example targets pipeline for pulling data from the Water Quality Portal (WQP)  
+# state-of-freshwater
+  
+A targets pipeline for pulling salinity data from the Water Quality Portal (WQP). This bones of the inventory and download phases of this pipeline come from the repo `USGS-R/ds-pipelines-targets-example-wqp`.
 
 ## Getting started
-To run the pipeline, check that you've installed the `targets` package in R and then run the following lines:  
+
+To run the pipeline, check that you've installed the appropriate packages. First, you will need the `targets` and `qs` packages. Then, you will need any other package listed next to the argument `packages` in the `tar_option_set()`function call near the top of the `_targets.R` file. 
+
+Once you have successfully installed those packages, run the following lines to build the full pipeline. Note that the inventory takes approximately 3.5 hours to run and the download takes approximately 15 hours.  
 
 ```r
-#install.packages("targets")
 library(targets)
 tar_make()
 ```
+
+You can also run the full pipeline using RStudio's "Background jobs":
+
+1) Open the `run_pipeline.R` file.
+2) Click on the "Background Jobs" tab in your console pane.
+3) Click "Start Background Job" and be sure that the `run_pipeline.R` file is selected (it should be by default if you did step 1).
+4) Follow along with the build progress in the "Background Jobs" tab. 
 
 ## Basic pipeline structure
 

--- a/_targets.R
+++ b/_targets.R
@@ -2,7 +2,8 @@ library(targets)
 
 options(tidyverse.quiet = TRUE)
 tar_option_set(packages = c('tidyverse', 'lubridate', 'dataRetrieval', 
-                            'sf', 'xml2', 'units', 'httr', 'MESS'))
+                            'sf', 'xml2', 'units', 'httr', 'MESS'),
+               format = "qs")
 
 source("1_inventory.R")
 source("2_download.R")


### PR DESCRIPTION
Change the default object type to `qs`, which are more compressed and have faster i/o. Changing the underlying object type for all targets caused a rebuild of everything. This PR also includes updates to the README so that it accurately reflects how to use this pipeline vs the template repo we started with.

With this new download, there are actually slightly fewer records (21,378,557 records which is 25k less than in #8) and the inventory/download steps took 3 hours in total (~1.5 hrs each, compared to almost 9 hrs for download alone). The download time significantly decreased, but part of me wonders if it was because I was on UW internet for most of it and before I was at home. The decrease in records is not super surprising just because WQP records change / are removed / are added all the time. Specifically, the number of `Specific conductance` records dropped and so did the number of sites:

![image](https://user-images.githubusercontent.com/13220910/211360914-be985d91-5c74-49a8-97e5-32b572f59b5c.png)

Here's how I got those values:
```r
# Time it takes to inventory the data and then download it all
library(targets)
tar_meta(p1_wqp_inventory)$seconds/3600
tar_meta(p2_wqp_data_aoi)$seconds/3600

# Number of resulting records
sum(readr::read_csv("2_download/log/summary_wqp_data.csv")$n_records)
```